### PR TITLE
HTP2WAV conversion fixes

### DIFF
--- a/src/htp2h2wav.c
+++ b/src/htp2h2wav.c
@@ -101,6 +101,8 @@ static void init_wav( FILE *wavfile ) {
     fwrite( &waveHeader, sizeof( waveHeader ), 1, wavfile );
     /* Lead in silence */
     write_peaks( wavfile, 2000, silence );
+    /* First sync peak */
+    write_peaks( wavfile, sync_us, high );
 }
 
 static void process_htp( FILE *input, FILE* output ) {

--- a/src/htp2h2wav.c
+++ b/src/htp2h2wav.c
@@ -106,10 +106,10 @@ static void init_wav( FILE *wavfile ) {
 }
 
 static void process_htp( FILE *input, FILE* output ) {
-    while ( !feof( input ) ) {
-        unsigned char c = fgetc( input );
-        // if ( !feof( input ) ) 
+    int c = fgetc(input);
+    while (c != EOF) {
         write_byte_into_wav( output, c );
+        c = fgetc(input);
     }
     fclose( input );
 //    write_byte_into_wav( output, 0 );


### PR DESCRIPTION
- We need to emit an initial sync peak, since the bitstream writer assumes it's already there.
- Avoid trailing 0xff garbage by stopping exactly at EOF, not after it
